### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Fix build error:
> A problem occurred configuring project ':react-native-orientation-locker'.
      > The SDK Build Tools revision (23.0.1) is too low for project ':react-native-orientation-locker'. Minimum required is 25.0.0